### PR TITLE
Disable GPG check on Red Hat

### DIFF
--- a/tasks/install-redhat-6.yml
+++ b/tasks/install-redhat-6.yml
@@ -11,6 +11,7 @@
 - name: Install {{ ssm_package }}.rpm
   yum:
     name: "/{{ ssm_temp_path }}/{{ ssm_package }}.rpm"
+    disable_gpg_check: true
     state: present
   when: not ssm_update
   tags:
@@ -19,6 +20,7 @@
 - name: Install/Update {{ ssm_package }}.rpm
   yum:
     name: "/{{ ssm_temp_path }}/{{ ssm_package }}.rpm"
+    disable_gpg_check: true
     state: latest
   when: ssm_update
   tags:

--- a/tasks/install-redhat-7.yml
+++ b/tasks/install-redhat-7.yml
@@ -11,6 +11,7 @@
 - name: Install {{ ssm_package }}.rpm
   yum:
     name: "/{{ ssm_temp_path }}/{{ ssm_package }}.rpm"
+    disable_gpg_check: true
     state: present
   when: not ssm_update
   tags:
@@ -19,6 +20,7 @@
 - name: Install/Update {{ ssm_package }}.rpm
   yum:
     name: "/{{ ssm_temp_path }}/{{ ssm_package }}.rpm"
+    disable_gpg_check: true
     state: latest
   when: ssm_update
   tags:

--- a/tasks/install-redhat-8.yml
+++ b/tasks/install-redhat-8.yml
@@ -11,6 +11,7 @@
 - name: Install {{ ssm_package }}.rpm
   dnf:
     name: "/{{ ssm_temp_path }}/{{ ssm_package }}.rpm"
+    disable_gpg_check: true
     state: present
   when: not ssm_update
   tags:
@@ -19,6 +20,7 @@
 - name: Install/Update {{ ssm_package }}.rpm
   dnf:
     name: "/{{ ssm_temp_path }}/{{ ssm_package }}.rpm"
+    disable_gpg_check: true
     state: latest
   when: ssm_update
   tags:


### PR DESCRIPTION
Similar to [ansible-role-amazon-cloudwatch-agent #4](https://github.com/christiangda/ansible-role-amazon-cloudwatch-agent/pull/4/files), this role currently fails when installing Amazon SSM agent on Red Hat because yum cannot verify the package, and Amazon still does not sign this package. I've tested the fix on RHEL 7, and I assume the fix will also work for other versions of Red Hat.