### PR TITLE
Oracle linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,9 @@ This role [Install AWS Systems Manager Agent](https://docs.aws.amazon.com/system
 
 ## Requirements
 
-This role work on RedHat, CentOS, Amazon Linux, Debian and Ubuntu distributions
+This role works on RedHat, CentOS, Oracle, Amazon Linux, Debian and Ubuntu distributions
 
-* RedHat
-  * 6
-  * 7
-  * 8
-* CentOS
+* RedHat/CentOS/Oracle
   * 6
   * 7
   * 8
@@ -53,7 +49,7 @@ None
 
 ## Example Playbook
 
-### RedHat/CentOS, Ubuntu and Debian
+### RedHat/CentOS/Oracle, Ubuntu and Debian
 
 ```yaml
 - hosts: servers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,14 +30,17 @@
     amazon_linux_recipe_name_result.stdout == 'amzn2'
 
 # Selective include of vars
-- name: Include variables for RedHat
+- name: Include variables for RedHat based disros
   include_vars: "{{ item }}"
   with_first_found:
     - "redhat.yml"
     - "main.yml"
   when: >
-    ansible_os_family == 'RedHat' and
-    ansible_distribution == 'RedHat'
+    ansible_os_family == 'RedHat' and (
+      ansible_distribution == 'RedHat' or
+      ansible_distribution == 'CentOS' or
+      ansible_distribution == 'OracleLinux'
+    )
     and (
       ansible_distribution_major_version == '8' or
       ansible_distribution_major_version == '7' or
@@ -45,22 +48,6 @@
     )
   tags:
     - include-redhat-vars
-
-- name: Include variables for CentOS
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "centos.yml"
-    - "main.yml"
-  when: >
-    ansible_os_family == 'RedHat' and
-    ansible_distribution == 'CentOS'
-    and (
-      ansible_distribution_major_version == '8' or
-      ansible_distribution_major_version == '7' or
-      ansible_distribution_major_version == '6'
-    )
-  tags:
-    - include-centos-vars
 
 - name: include variables for Amazon Linux
   include_vars: "{{ item }}"
@@ -100,8 +87,9 @@
   include_tasks: "install-{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml"
   when: >
     ansible_os_family == 'RedHat' and (
+      ansible_distribution == 'RedHat' or
       ansible_distribution == 'CentOS' or
-      ansible_distribution == 'RedHat'
+      ansible_distribution == 'OracleLinux'
     )
   tags:
     - include-redhat-tasks
@@ -138,8 +126,9 @@
   include_tasks: "configure-{{ ansible_os_family|lower }}-{{ ansible_distribution_major_version }}.yml"
   when: >
     ansible_os_family == 'RedHat' and (
+      ansible_distribution == 'RedHat' or
       ansible_distribution == 'CentOS' or
-      ansible_distribution == 'RedHat'
+      ansible_distribution == 'OracleLinux'
     )
   tags:
     - include-configure-redhat

--- a/vars/centos.yml
+++ b/vars/centos.yml
@@ -1,2 +1,0 @@
----
-ssm_package_url: https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm


### PR DESCRIPTION
I needed to add Oracle Linux to the list of supported RedHat Based distros. I also cleaned the include vars up a bit since the values for RedHat and CentOS were the same. Then I reordered the checks so that they all matched.